### PR TITLE
Include the polygon vertices for WithIn query

### DIFF
--- a/geojson/geojson_s2_util.go
+++ b/geojson/geojson_s2_util.go
@@ -185,7 +185,7 @@ func s2PolygonFromCoordinates(coordinates [][][]float64) *s2.Polygon {
 		loops = append(loops, s2loop)
 	}
 
-	rv := s2.PolygonFromLoops(loops)
+	rv := s2.PolygonFromOrientedLoops(loops)
 	return rv
 }
 

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -1270,6 +1270,16 @@ func checkMultiPolygonContainsShape(s2pgns []*s2.Polygon,
 				if s2pgn.ContainsPoint(*point) {
 					pointsWithIn[pointIndex] = struct{}{}
 					continue nextPoint
+				} else {
+					// double check for containment with the vertices.
+					for _, loop := range s2pgn.Loops() {
+						for i := 0; i < loop.NumVertices(); i++ {
+							if point.ApproxEqual(loop.Vertex(i)) {
+								pointsWithIn[pointIndex] = struct{}{}
+								continue nextPoint
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
-Consider the polygon vertices for checking the
 containment for the points during a within filtering.
-Move to PolygonFromOrientedLoops s2 api.