### PR TITLE
Added disjoint relation

### DIFF
--- a/geojson/geojson_shapes_util.go
+++ b/geojson/geojson_shapes_util.go
@@ -206,6 +206,11 @@ func filterShapes(shape index.GeoJSON,
 		return shape.Contains(shapeInDoc)
 	}
 
+	if relation == "disjoint" {
+		intersects, err := shape.Intersects(shapeInDoc)
+		return !intersects, err
+	}
+
 	return false, fmt.Errorf("unknown relation: %s", relation)
 }
 


### PR DESCRIPTION
This PR adds a fourth geoshape relation 'disjoint', which is the inverse of the intersection relation. 