### PR TITLE
Fix for linestrings enclosed by polygon

### DIFF
--- a/geojson/geojson_s2_util.go
+++ b/geojson/geojson_s2_util.go
@@ -40,6 +40,19 @@ func polylineIntersectsPoint(pls []*s2.Polyline,
 
 func polylineIntersectsPolygons(pls []*s2.Polyline,
 	s2pgns []*s2.Polygon) bool {
+	// Early exit if the polygon contains any of the line's vertices.
+	for _, pl := range pls {
+		for i := 0; i < pl.NumEdges(); i++ {
+			edge := pl.Edge(i)
+			for _, s2pgn := range s2pgns {
+				if s2pgn.IntersectsCell(s2.CellFromPoint(edge.V0)) ||
+					s2pgn.IntersectsCell(s2.CellFromPoint(edge.V1)) {
+					return true
+				}
+			}
+		}
+	}
+
 	for _, pl := range pls {
 		for _, s2pgn := range s2pgns {
 			for i := 0; i < pl.NumEdges(); i++ {
@@ -72,30 +85,6 @@ func geometryCollectionIntersectsShape(gc *GeometryCollection,
 			return true
 		}
 	}
-	return false
-}
-
-func polygonsIntersectsLinestrings(s2pgn *s2.Polygon,
-	pls []*s2.Polyline) bool {
-	for _, pl := range pls {
-		for i := 0; i < pl.NumEdges(); i++ {
-			edge := pl.Edge(i)
-			a := []float64{edge.V0.X, edge.V0.Y}
-			b := []float64{edge.V1.X, edge.V1.Y}
-
-			for j := 0; j < s2pgn.NumEdges(); j++ {
-				edgeB := s2pgn.Edge(j)
-
-				c := []float64{edgeB.V0.X, edgeB.V0.Y}
-				d := []float64{edgeB.V1.X, edgeB.V1.Y}
-
-				if doIntersect(a, b, c, d) {
-					return true
-				}
-			}
-		}
-	}
-
 	return false
 }
 

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -1232,8 +1232,8 @@ func checkPolygonIntersectsShape(s2pgn *s2.Polygon, shapeIn,
 	// check if the other shape is a linestring.
 	if ls, ok := other.(*LineString); ok {
 
-		if polygonsIntersectsLinestrings(s2pgn,
-			[]*s2.Polyline{ls.pl}) {
+		if polylineIntersectsPolygons([]*s2.Polyline{ls.pl},
+			[]*s2.Polygon{s2pgn}) {
 			return true, nil
 		}
 
@@ -1243,7 +1243,7 @@ func checkPolygonIntersectsShape(s2pgn *s2.Polygon, shapeIn,
 	// check if the other shape is a multilinestring.
 	if mls, ok := other.(*MultiLineString); ok {
 
-		if polygonsIntersectsLinestrings(s2pgn, mls.pls) {
+		if polylineIntersectsPolygons(mls.pls, []*s2.Polygon{s2pgn}) {
 			return true, nil
 		}
 

--- a/geojson/geojson_shapes_util.go
+++ b/geojson/geojson_shapes_util.go
@@ -391,6 +391,12 @@ var GlueBytes = []byte("##")
 // can be used later while filering the doc values.
 func NewGeometryCollection(coordinates [][][][][]float64,
 	typs []string) (index.GeoJSON, []byte, error) {
+	if typs == nil {
+		return nil, nil, fmt.Errorf("nil type information")
+	}
+	if len(typs) < len(coordinates) {
+		return nil, nil, fmt.Errorf("missing type information for some shapes")
+	}
 	shapes := make([]index.GeoJSON, 0, len(coordinates))
 	for i, vertices := range coordinates {
 		s, _, err := NewGeoJsonShape(vertices, typs[i])


### PR DESCRIPTION
Currently, linestrings enclosed completely by polygons are not considered intersecting. This PR addresses that by adding a condition of at least one point on the edges of a linestring to be intersecting with a polygon.

This PR also adds a check for checking the number of types and for a nil type when resolving geometry collections to avoid panics. Currently, nil/insufficient length types cause panics.