### PR TITLE
MB-66210: Point and MultiPoint changes

### DIFF
--- a/geojson/geojson_s2_util.go
+++ b/geojson/geojson_s2_util.go
@@ -25,12 +25,13 @@ import (
 
 // ------------------------------------------------------------------------
 
+// project the point to all of the linestrings and check if
+// any of the projections are equal to the point.
 func polylineIntersectsPoint(pls []*s2.Polyline,
 	point *s2.Point) bool {
-	s2cell := s2.CellFromPoint(*point)
-
 	for _, pl := range pls {
-		if pl.IntersectsCell(s2cell) {
+		closest, _ := pl.Project(*point)
+		if closest.ApproxEqual(*point) {
 			return true
 		}
 	}
@@ -243,20 +244,6 @@ func s2Cap(vertices []float64, radiusInMeter float64) *s2.Cap {
 	angle := radiusInMetersToS1Angle(float64(radiusInMeter))
 	cap := s2.CapFromCenterAngle(cp, angle)
 	return &cap
-}
-
-func max(a, b float64) float64 {
-	if a >= b {
-		return a
-	}
-	return b
-}
-
-func min(a, b float64) float64 {
-	if a >= b {
-		return b
-	}
-	return a
 }
 
 func StripCoveringTerms(terms []string) []string {

--- a/geojson/geojson_s2_util.go
+++ b/geojson/geojson_s2_util.go
@@ -19,11 +19,24 @@ import (
 	"strings"
 
 	index "github.com/blevesearch/bleve_index_api"
-	"github.com/blevesearch/geo/s2"
 	"github.com/blevesearch/geo/s1"
+	"github.com/blevesearch/geo/s2"
 )
 
 // ------------------------------------------------------------------------
+
+// creates a shape index with all of the given polygons
+// and queries it with vertex model closed which considers
+// polygon edges and vertices to be part of the polygon.
+func polygonsContainsPoint(s2pgns []*s2.Polygon,
+	point *s2.Point) bool {
+	idx := s2.NewShapeIndex()
+	for _, s2pgn := range s2pgns {
+		idx.Add(s2pgn)
+	}
+
+	return s2.NewContainsPointQuery(idx, s2.VertexModelClosed).Contains(*point)
+}
 
 // project the point to all of the linestrings and check if
 // any of the projections are equal to the point.

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -892,7 +892,7 @@ func (e *Envelope) Contains(other index.GeoJSON) (bool, error) {
 func checkPointIntersectsShape(point *s2.Point, shapeIn, other index.GeoJSON) (bool, error) {
 	// check if the other shape is a point.
 	if p2, ok := other.(*Point); ok {
-		// Check if the points are equal
+		// check if the points are equal
 		if point.ApproxEqual(*p2.s2point) {
 			return true, nil
 		}
@@ -915,11 +915,7 @@ func checkPointIntersectsShape(point *s2.Point, shapeIn, other index.GeoJSON) (b
 	// check if the other shape is a polygon.
 	if p2, ok := other.(*Polygon); ok {
 		// check if the point is contained within the polygon.
-		// polygon contains point will consider vertices to be outside
-		// so we create a shape index and query it instead
-		idx := s2.NewShapeIndex()
-		idx.Add(p2.s2pgn)
-		if s2.NewContainsPointQuery(idx, s2.VertexModelClosed).Contains(*point) {
+		if polygonsContainsPoint([]*s2.Polygon{p2.s2pgn}, point) {
 			return true, nil
 		}
 
@@ -929,13 +925,7 @@ func checkPointIntersectsShape(point *s2.Point, shapeIn, other index.GeoJSON) (b
 	// check if the other shape is a multipolygon.
 	if p2, ok := other.(*MultiPolygon); ok {
 		// check if the point is contained within any of the polygons
-		// polygon contains point will consider vertices to be outside
-		// so we create a shape index and query it instead
-		idx := s2.NewShapeIndex()
-		for _, s2pgn := range p2.s2pgns {
-			idx.Add(s2pgn)
-		}
-		if s2.NewContainsPointQuery(idx, s2.VertexModelClosed).Contains(*point) {
+		if polygonsContainsPoint(p2.s2pgns, point) {
 			return true, nil
 		}
 

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -946,8 +946,7 @@ func checkPointIntersectsShape(point *s2.Point, shapeIn, other index.GeoJSON) (b
 	if p2, ok := other.(*LineString); ok {
 		// project the point to the linestring and check if
 		// the projection is equal to the point.
-		closest, _ := p2.pl.Project(*point)
-		if closest.ApproxEqual(*point) {
+		if polylineIntersectsPoint([]*s2.Polyline{p2.pl}, point) {
 			return true, nil
 		}
 
@@ -957,11 +956,8 @@ func checkPointIntersectsShape(point *s2.Point, shapeIn, other index.GeoJSON) (b
 	// check if the other shape is a multilinestring.
 	if p2, ok := other.(*MultiLineString); ok {
 		// check the intersection for any linestring in the array.
-		for _, pl := range p2.pls {
-			closest, _ := pl.Project(*point)
-			if closest.ApproxEqual(*point) {
-				return true, nil
-			}
+		if polylineIntersectsPoint(p2.pls, point) {
+			return true, nil
 		}
 
 		return false, nil

--- a/geojson/geojson_shapes_test.go
+++ b/geojson/geojson_shapes_test.go
@@ -1,0 +1,381 @@
+//  Copyright (c) 2025 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geojson
+
+import (
+	"testing"
+
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+func TestPointIntersects(t *testing.T) {
+
+	tests := []struct {
+		queryPoint *Point
+		other      index.GeoJSON
+		output     bool
+	}{
+		{ // 0 - Same point with 15 decimal places
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234567, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 1 - Point with 15th decimal place differing
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234568, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 2 - Point with 13th decimal place differing
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234667, 1.234567891234567}),
+			output:     false,
+		},
+		{ // 3 - MultiPoint with a match
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.134567891234567, 1.234567891234567}, {1.234567891234567, 1.234567891234567}}),
+			output:     true,
+		},
+		{ // 4 - MultiPoint with no match
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.234567891234567, 1.134567891234567}, {1.134567891234567, 1.234567891234567}}),
+			output:     false,
+		},
+		{ // 5 - Polygon with point on the inside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 6 - Clockwise polygon with point on the outside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {-1, 1}, {1, 1}, {1, -1}, {-1, -1}}}),
+			output:     false,
+		},
+		{ // 7 - Polygon with point on the vertex
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{-1, -1}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 8 - Polygon with point on the edge
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0.5, 1}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 9 - Polygon with point in the hole
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}, {{-0.5, -0.5}, {-0.5, 0.5}, {0.5, 0.5}, {0.5, -0.5}, {-0.5, -0.5}}}),
+			output:     false,
+		},
+		{ // 10 - MulitiPolygon with point
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{2.5, 2.5}},
+			other:      NewGeoJsonMultiPolygon([][][][]float64{{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}, {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}}),
+			output:     true,
+		},
+		{ // 11 - MultiPolygon without point
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{2.5, 2.5}},
+			other:      NewGeoJsonMultiPolygon([][][][]float64{{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}, {{{-2, -2}, {-3, -2}, {-3, -3}, {-2, -3}, {-2, -2}}}}),
+			output:     false,
+		},
+		{ // 12 - LineString with point on the line
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     true,
+		},
+		{ // 13 - LineString with point on the vertex
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{-1, 0}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     true,
+		},
+		{ // 14 - LineString with point not on line
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{-2, 0}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     false,
+		},
+		{ // 15 - MultiLineString with point on the line
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1, 0}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-5, 0}, {-3, 0}}, {{-2, 0}, {2, 0}}}),
+			output:     true,
+		},
+		{ // 16 - MultiLineString with point on the vertex
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{2, 1}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-1, 0}, {1, 0}}, {{-2, 1}, {2, 1}}}),
+			output:     true,
+		},
+		{ // 17 - MultiLineString with point not on line
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{-3, 1}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-1, 0}, {1, 0}}, {{-2, 1}, {2, 1}}}),
+			output:     false,
+		},
+		{ // 18 - Circle with point not on the inside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 2}},
+			other:      NewGeoCircle([]float64{0, 0}, "1km"),
+			output:     false,
+		},
+		{ // 19 - Circle with point on the inside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0.03}},
+			other:      NewGeoCircle([]float64{0, 0}, "10km"),
+			output:     true,
+		},
+		{ // 20 - Envelope with point on the inside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{0, 0}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     true,
+		},
+		{ // 21 - Envelope with point on the outside
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{3, 2}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     false,
+		},
+		{ // 22 - Envelope with point on the edge
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1, 2}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     true,
+		},
+	}
+
+	for i, test := range tests {
+		result, err := test.queryPoint.Intersects(test.other)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		if result != test.output {
+			t.Errorf("Test - %d, expected %v, got %v", i, test.output, result)
+		}
+	}
+}
+
+func TestMultiPointIntersects(t *testing.T) {
+	tests := []struct {
+		queryPoint *MultiPoint
+		other      index.GeoJSON
+		output     bool
+	}{
+		{ // 0 - Same point with 15 decimal places
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234567, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 1 - Point with 15th decimal place differing
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234568, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 2 - Point with 13th decimal place differing
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234667, 1.234567891234567}),
+			output:     false,
+		},
+		{ // 3 - MultiPoint with a match
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.134567891234567, 1.234567891234567}, {1.234567891234567, 1.234567891234567}}),
+			output:     true,
+		},
+		{ // 4 - MultiPoint with no match
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.234567891234567, 1.134567891234567}, {1.134567891234567, 1.234567891234567}}),
+			output:     false,
+		},
+		{ // 5 - Polygon with point on the inside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{0, 0}, {4, 4}}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 6 - Clockwise polygon with point on the outside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{0.5, 0.5}, {0, 0}}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {-1, 1}, {1, 1}, {1, -1}, {-1, -1}}}),
+			output:     false,
+		},
+		{ // 7 - Polygon with point on the vertex
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {-1, -1}}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 8 - Polygon with point on the vertex
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{-0.5, -1}, {4, 4}}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}),
+			output:     true,
+		},
+		{ // 9 - Polygon with point in the hole
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{0, 0}, {4, 4}}},
+			other:      NewGeoJsonPolygon([][][]float64{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}, {{-0.5, -0.5}, {-0.5, 0.5}, {0.5, 0.5}, {0.5, -0.5}, {-0.5, -0.5}}}),
+			output:     false,
+		},
+		{ // 10 - MulitiPolygon with point
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {0, 0}}},
+			other:      NewGeoJsonMultiPolygon([][][][]float64{{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}, {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}}),
+			output:     true,
+		},
+		{ // 11 - MultiPolygon without point
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {-4, -4}}},
+			other:      NewGeoJsonMultiPolygon([][][][]float64{{{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}, {-1, -1}}}, {{{-2, -2}, {-3, -2}, {-3, -3}, {-2, -3}, {-2, -2}}}}),
+			output:     false,
+		},
+		{ // 12 - LineString with point on the line
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{0, 0}, {-1, -1}}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     true,
+		},
+		{ // 13 - LineString with point on the vertex
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1, 0}, {4, 4}}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     true,
+		},
+		{ // 14 - LineString with point not on line
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {2, 3}}},
+			other:      NewGeoJsonLinestring([][]float64{{-1, 0}, {1, 0}}),
+			output:     false,
+		},
+		{ // 15 - MultiLineString with point on the line
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{-2, 0}, {4, 4}}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-5, 0}, {-3, 0}}, {{-2, 0}, {2, 0}}}),
+			output:     true,
+		},
+		{ // 16 - MultiLineString with point on the vertex
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {-2, 1}}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-1, 0}, {1, 0}}, {{-2, 1}, {2, 1}}}),
+			output:     true,
+		},
+		{ // 17 - MultiLineString with point not on line
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1, -1}, {4, 4}}},
+			other:      NewGeoJsonMultilinestring([][][]float64{{{-1, 0}, {1, 0}}, {{-2, 1}, {2, 1}}}),
+			output:     false,
+		},
+		{ // 18 - Circle with point not on the inside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {-1, -3}}},
+			other:      NewGeoCircle([]float64{0, 0}, "1km"),
+			output:     false,
+		},
+		{ // 19 - Circle with point on the inside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{0.024, -0.037}, {4, 4}}},
+			other:      NewGeoCircle([]float64{0, 0}, "10km"),
+			output:     true,
+		},
+		{ // 20 - Envelope with point on the inside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {0, 0}}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     true,
+		},
+		{ // 21 - Envelope with point on the outside
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{-2, -3}, {4, 4}}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     false,
+		},
+		{ // 22 - Envelope with point on the edge
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{4, 4}, {-1, -2}}},
+			other:      NewGeoEnvelope([][]float64{{-2, 2}, {2, -2}}),
+			output:     true,
+		},
+	}
+
+	for i, test := range tests {
+		result, err := test.queryPoint.Intersects(test.other)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		if result != test.output {
+			t.Errorf("Test - %d, expected %v, got %v", i, test.output, result)
+		}
+	}
+}
+
+func TestPointContains(t *testing.T) {
+	tests := []struct {
+		queryPoint *Point
+		other      index.GeoJSON
+		output     bool
+	}{
+		{ // 0 - Same point with 15 decimal places
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234567, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 1 - Point with 15th decimal place differing
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234568, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 2 - Point with 13th decimal place differing
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234667, 1.234567891234567}),
+			output:     false,
+		},
+		{ // 3 - MultiPoint with a match
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.234567891234567, 1.234567891234567}}),
+			output:     true,
+		},
+		{ // 4 - MultiPoint with no match
+			queryPoint: &Point{Typ: PointType, Vertices: []float64{1.234567891234567, 1.234567891234567}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.234567891234567, 1.134567891234567}, {1.134567891234567, 1.234567891234567}}),
+			output:     false,
+		},
+	}
+
+	for i, test := range tests {
+		result, err := test.queryPoint.Contains(test.other)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		if result != test.output {
+			t.Errorf("Test - %d, expected %v, got %v", i, test.output, result)
+		}
+	}
+}
+func TestMultiPointContains(t *testing.T) {
+	tests := []struct {
+		queryPoint *MultiPoint
+		other      index.GeoJSON
+		output     bool
+	}{
+		{ // 0 - Same point with 15 decimal places
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234567, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 1 - Point with 15th decimal place differing
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234568, 1.234567891234567}),
+			output:     true,
+		},
+		{ // 2 - Point with 13th decimal place differing
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonPoint([]float64{1.234567891234667, 1.234567891234567}),
+			output:     false,
+		},
+		{ // 3 - MultiPoint with a match
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonMultiPoint([][]float64{{2.234567891234567, 2.234567891234567}, {1.234567891234567, 1.234567891234567}}),
+			output:     true,
+		},
+		{ // 4 - MultiPoint with no match
+			queryPoint: &MultiPoint{Typ: PointType, Vertices: [][]float64{{1.234567891234567, 1.234567891234567}, {2.234567891234567, 2.234567891234567}}},
+			other:      NewGeoJsonMultiPoint([][]float64{{1.234567891234567, 1.134567891234567}, {1.134567891234567, 1.234567891234567}}),
+			output:     false,
+		},
+	}
+
+	for i, test := range tests {
+		result, err := test.queryPoint.Contains(test.other)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		if result != test.output {
+			t.Errorf("Test - %d, expected %v, got %v", i, test.output, result)
+		}
+	}
+}


### PR DESCRIPTION
 - Switched out all cell operations to point operations
 - All point comparisons will use approx equal which has an epsilon of 1e-15
 - LineStrings and MultiLineStrings will project point onto themselves and compare the distance between points for intersection
 - Polygons and MultiPolygons use shape indexes with a Closed Vertex Model which means the boundaries and the vertices are considered part of the shape
 - Circle will use distance from center to identify intersecting points
 - Envelopes will use bound checks to identify intersects
 - New Circles and Envelopes will now init themselves before returning
 - Removed a couple of unused functions
 - Added appropriate test cases

Note:
    Projection onto a segment calculation might not be completely accurate. Projection of point (1,1) onto the line (-2,1) and (2,1) returns a point that has a distance of 50m from (1,1). Unable to verify if this distance is actually accurate or not.
    Converting the point to a cell and then doing an intersects with the linestring still gives a a false which leads me to believe that the distance it is giving is actually correct.