### PR TITLE
MB-70122: Use a better method to compute envelope intersects circle queries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Test on supported go compiler releases as well as the oldest version we support from go.mod.
-        go: [ '1.21', 'oldstable', 'stable' ]
+        go: [ '1.24', 'oldstable', 'stable' ]
     name: Go version ${{ matrix.go }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -1717,7 +1717,10 @@ func checkEnvelopeIntersectsShape(s2rect *s2.Rect, shapeIn,
 
 	// check if the other shape is a circle.
 	if c, ok := other.(*Circle); ok {
-		if s2rect.DistanceToLatLng(s2.LatLngFromPoint(c.s2cap.Center())) <= c.s2cap.Radius() {
+		// check if the distance of the center of the circle from the
+		// rectangle is less than the radius of the circle.
+		if s2rect.DistanceToLatLng(s2.LatLngFromPoint(c.s2cap.Center())) <=
+			c.s2cap.Radius() {
 			return true, nil
 		}
 

--- a/geojson/geojson_shapes_impl.go
+++ b/geojson/geojson_shapes_impl.go
@@ -1717,11 +1717,11 @@ func checkEnvelopeIntersectsShape(s2rect *s2.Rect, shapeIn,
 
 	// check if the other shape is a circle.
 	if c, ok := other.(*Circle); ok {
-		s2pgn := s2PolygonFromS2Rectangle(s2rect)
-		cp := c.s2cap.Center()
-		projected := s2pgn.Project(&cp)
-		distance := projected.Distance(cp)
-		return distance <= c.s2cap.Radius(), nil
+		if s2rect.DistanceToLatLng(s2.LatLngFromPoint(c.s2cap.Center())) <= c.s2cap.Radius() {
+			return true, nil
+		}
+
+		return false, nil
 	}
 
 	// check if the other shape is a envelope.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/blevesearch/geo
 
 // This declares what language features we use and may be updated freely up to "oldstable".
 // Update .github/workflows/go.yml when bumping this version.
-go 1.21.0
+go 1.24
 
 require (
-	github.com/blevesearch/bleve_index_api v1.2.8
+	github.com/blevesearch/bleve_index_api v1.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blevesearch/bleve_index_api v1.2.8 h1:Y98Pu5/MdlkRyLM0qDHostYo7i+Vv1cDNhqTeR4Sy6Y=
-github.com/blevesearch/bleve_index_api v1.2.8/go.mod h1:rKQDl4u51uwafZxFrPD1R7xFOwKnzZW7s/LSeK4lgo0=
+github.com/blevesearch/bleve_index_api v1.3.1 h1:LdH3CQgBbIZ5UI/5Pykz87e0jfeQtVnrdZ2WUBrHHwU=
+github.com/blevesearch/bleve_index_api v1.3.1/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
 - Switched from converting envelope to rectangle and then finding distance to directly finding the distance from the envelope
 - Theoretically should be faster than converting to a rectangle